### PR TITLE
feat(frontend): add artisan profile edit sections

### DIFF
--- a/src/app/(dashboard)/artisan/profile/page.tsx
+++ b/src/app/(dashboard)/artisan/profile/page.tsx
@@ -1,0 +1,41 @@
+import { ProfileIdentitySection } from "@/components/artisan/profile-identity-section"
+import { ProfileSkillsSection } from "@/components/artisan/profile-skills-section"
+import { ProfileLocationSection } from "@/components/artisan/profile-location-section"
+
+// Mock data — replace with real data fetching once API is available
+const mockProfile = {
+  identity: {
+    fullName: "Samuel Adeyemi",
+    email: "samuel@example.com",
+    phone: "+234 800 000 0000",
+  },
+  skills: {
+    skillCategory: "Carpentry",
+    yearsOfExperience: "3-5 years",
+    bio: "Experienced carpenter specialising in custom furniture and home renovations.",
+  },
+  location: {
+    state: "Lagos",
+    city: "Ikeja",
+    address: "",
+  },
+}
+
+export default function ProfilePage() {
+  return (
+    <div className="w-full max-w-2xl">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">Edit Profile</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Keep your profile up to date so clients can find and trust you.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <ProfileIdentitySection initialData={mockProfile.identity} />
+        <ProfileSkillsSection initialData={mockProfile.skills} />
+        <ProfileLocationSection initialData={mockProfile.location} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/artisan/profile-identity-section.tsx
+++ b/src/components/artisan/profile-identity-section.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useState } from "react"
+import { CheckCircle } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface IdentityData {
+  fullName: string
+  email: string
+  phone: string
+}
+
+interface ProfileIdentitySectionProps {
+  initialData: IdentityData
+}
+
+export function ProfileIdentitySection({ initialData }: ProfileIdentitySectionProps) {
+  const [data, setData] = useState<IdentityData>(initialData)
+  const [errors, setErrors] = useState<Partial<IdentityData>>({})
+  const [saved, setSaved] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  const validate = (): boolean => {
+    const newErrors: Partial<IdentityData> = {}
+    if (!data.fullName.trim()) newErrors.fullName = "Full name is required"
+    if (!data.email.trim()) {
+      newErrors.email = "Email is required"
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+      newErrors.email = "Enter a valid email address"
+    }
+    if (data.phone && !/^\+?[\d\s\-()]{7,15}$/.test(data.phone)) {
+      newErrors.phone = "Enter a valid phone number"
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!validate()) return
+    setSaving(true)
+    // TODO: replace with real API call
+    await new Promise((r) => setTimeout(r, 600))
+    setSaving(false)
+    setSaved(true)
+    setTimeout(() => setSaved(false), 3000)
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-1">Identity</h2>
+      <p className="text-sm text-gray-500 mb-5">Your basic personal information</p>
+
+      <form onSubmit={handleSave} noValidate className="space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="fullName" className="text-sm font-medium text-gray-700">Full Name</Label>
+          <Input
+            id="fullName"
+            value={data.fullName}
+            onChange={(e) => setData({ ...data, fullName: e.target.value })}
+            placeholder="Your full name"
+            className={`h-11 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[#605DEC] ${errors.fullName ? "border-red-400" : ""}`}
+          />
+          {errors.fullName && <p className="text-xs text-red-500">{errors.fullName}</p>}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="email" className="text-sm font-medium text-gray-700">Email Address</Label>
+          <Input
+            id="email"
+            type="email"
+            value={data.email}
+            onChange={(e) => setData({ ...data, email: e.target.value })}
+            placeholder="you@example.com"
+            className={`h-11 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[#605DEC] ${errors.email ? "border-red-400" : ""}`}
+          />
+          {errors.email && <p className="text-xs text-red-500">{errors.email}</p>}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="phone" className="text-sm font-medium text-gray-700">Phone Number <span className="text-gray-400 font-normal">(optional)</span></Label>
+          <Input
+            id="phone"
+            type="tel"
+            value={data.phone}
+            onChange={(e) => setData({ ...data, phone: e.target.value })}
+            placeholder="+234 800 000 0000"
+            className={`h-11 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[#605DEC] ${errors.phone ? "border-red-400" : ""}`}
+          />
+          {errors.phone && <p className="text-xs text-red-500">{errors.phone}</p>}
+        </div>
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-5 py-2 rounded-lg bg-[#605DEC] text-white text-sm font-medium hover:bg-[#5558e3] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? "Saving…" : "Save Changes"}
+          </button>
+          {saved && (
+            <span className="flex items-center gap-1.5 text-sm text-green-600">
+              <CheckCircle className="w-4 h-4" /> Saved
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/artisan/profile-location-section.tsx
+++ b/src/components/artisan/profile-location-section.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import { useState } from "react"
+import { CheckCircle } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const nigerianStates = [
+  "Abia", "Adamawa", "Akwa Ibom", "Anambra", "Bauchi", "Bayelsa", "Benue",
+  "Borno", "Cross River", "Delta", "Ebonyi", "Edo", "Ekiti", "Enugu",
+  "FCT (Abuja)", "Gombe", "Imo", "Jigawa", "Kaduna", "Kano", "Katsina",
+  "Kebbi", "Kogi", "Kwara", "Lagos", "Nasarawa", "Niger", "Ogun", "Ondo",
+  "Osun", "Oyo", "Plateau", "Rivers", "Sokoto", "Taraba", "Yobe", "Zamfara",
+]
+
+interface LocationData {
+  state: string
+  city: string
+  address: string
+}
+
+interface ProfileLocationSectionProps {
+  initialData: LocationData
+}
+
+export function ProfileLocationSection({ initialData }: ProfileLocationSectionProps) {
+  const [data, setData] = useState<LocationData>(initialData)
+  const [errors, setErrors] = useState<Partial<LocationData>>({})
+  const [saved, setSaved] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  const validate = (): boolean => {
+    const newErrors: Partial<LocationData> = {}
+    if (!data.state) newErrors.state = "Please select a state"
+    if (!data.city.trim()) newErrors.city = "City is required"
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!validate()) return
+    setSaving(true)
+    // TODO: replace with real API call
+    await new Promise((r) => setTimeout(r, 600))
+    setSaving(false)
+    setSaved(true)
+    setTimeout(() => setSaved(false), 3000)
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-1">Location</h2>
+      <p className="text-sm text-gray-500 mb-5">Where you are based and available to work</p>
+
+      <form onSubmit={handleSave} noValidate className="space-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium text-gray-700">State</Label>
+            <Select
+              value={data.state}
+              onValueChange={(v) => setData({ ...data, state: v })}
+            >
+              <SelectTrigger className={`h-11 focus:ring-0 focus:ring-offset-0 focus:border-[#605DEC] ${errors.state ? "border-red-400" : ""}`}>
+                <SelectValue placeholder="Choose State" />
+              </SelectTrigger>
+              <SelectContent className="rounded-lg border border-gray-200 bg-white shadow-lg max-h-72 overflow-y-auto">
+                {nigerianStates.map((state) => (
+                  <SelectItem key={state} value={state} className="cursor-pointer focus:bg-gray-100 px-3 py-2 text-sm">
+                    {state}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.state && <p className="text-xs text-red-500">{errors.state}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="city" className="text-sm font-medium text-gray-700">City</Label>
+            <Input
+              id="city"
+              value={data.city}
+              onChange={(e) => setData({ ...data, city: e.target.value })}
+              placeholder="Enter your city"
+              className={`h-11 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[#605DEC] ${errors.city ? "border-red-400" : ""}`}
+            />
+            {errors.city && <p className="text-xs text-red-500">{errors.city}</p>}
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="address" className="text-sm font-medium text-gray-700">Street Address <span className="text-gray-400 font-normal">(optional)</span></Label>
+          <Input
+            id="address"
+            value={data.address}
+            onChange={(e) => setData({ ...data, address: e.target.value })}
+            placeholder="e.g. 12 Broad Street"
+            className="h-11 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[#605DEC]"
+          />
+        </div>
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-5 py-2 rounded-lg bg-[#605DEC] text-white text-sm font-medium hover:bg-[#5558e3] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? "Saving…" : "Save Changes"}
+          </button>
+          {saved && (
+            <span className="flex items-center gap-1.5 text-sm text-green-600">
+              <CheckCircle className="w-4 h-4" /> Saved
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/artisan/profile-skills-section.tsx
+++ b/src/components/artisan/profile-skills-section.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { useState } from "react"
+import { CheckCircle } from "lucide-react"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const skillCategories = [
+  "Carpentry",
+  "Plumbing",
+  "Electrical",
+  "Painting",
+  "Welding",
+  "Masonry",
+  "Tailoring",
+  "Photography",
+  "Graphic Design",
+  "Other",
+]
+
+const experienceOptions = [
+  "Less than 1 year",
+  "1-2 years",
+  "3-5 years",
+  "5-10 years",
+  "10+ years",
+]
+
+interface SkillsData {
+  skillCategory: string
+  yearsOfExperience: string
+  bio: string
+}
+
+interface ProfileSkillsSectionProps {
+  initialData: SkillsData
+}
+
+export function ProfileSkillsSection({ initialData }: ProfileSkillsSectionProps) {
+  const [data, setData] = useState<SkillsData>(initialData)
+  const [errors, setErrors] = useState<Partial<SkillsData>>({})
+  const [saved, setSaved] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  const validate = (): boolean => {
+    const newErrors: Partial<SkillsData> = {}
+    if (!data.skillCategory) newErrors.skillCategory = "Please select a skill category"
+    if (!data.yearsOfExperience) newErrors.yearsOfExperience = "Please select years of experience"
+    if (!data.bio.trim()) {
+      newErrors.bio = "Bio is required"
+    } else if (data.bio.trim().length < 20) {
+      newErrors.bio = "Bio must be at least 20 characters"
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!validate()) return
+    setSaving(true)
+    // TODO: replace with real API call
+    await new Promise((r) => setTimeout(r, 600))
+    setSaving(false)
+    setSaved(true)
+    setTimeout(() => setSaved(false), 3000)
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-1">Skills & Experience</h2>
+      <p className="text-sm text-gray-500 mb-5">Your craft, expertise level, and professional bio</p>
+
+      <form onSubmit={handleSave} noValidate className="space-y-4">
+        <div className="space-y-1.5">
+          <Label className="text-sm font-medium text-gray-700">Craft / Skill Category</Label>
+          <Select
+            value={data.skillCategory}
+            onValueChange={(v) => setData({ ...data, skillCategory: v })}
+          >
+            <SelectTrigger className={`h-11 focus:ring-0 focus:ring-offset-0 focus:border-[#605DEC] ${errors.skillCategory ? "border-red-400" : ""}`}>
+              <SelectValue placeholder="Choose a skill/category" />
+            </SelectTrigger>
+            <SelectContent className="rounded-lg border border-gray-200 bg-white shadow-lg max-h-72 overflow-y-auto">
+              {skillCategories.map((cat) => (
+                <SelectItem key={cat} value={cat} className="cursor-pointer focus:bg-gray-100 px-3 py-2 text-sm">
+                  {cat}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.skillCategory && <p className="text-xs text-red-500">{errors.skillCategory}</p>}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label className="text-sm font-medium text-gray-700">Years of Experience</Label>
+          <Select
+            value={data.yearsOfExperience}
+            onValueChange={(v) => setData({ ...data, yearsOfExperience: v })}
+          >
+            <SelectTrigger className={`h-11 focus:ring-0 focus:ring-offset-0 focus:border-[#605DEC] ${errors.yearsOfExperience ? "border-red-400" : ""}`}>
+              <SelectValue placeholder="Choose an option" />
+            </SelectTrigger>
+            <SelectContent className="rounded-lg border border-gray-200 bg-white shadow-lg max-h-72 overflow-y-auto">
+              {experienceOptions.map((opt) => (
+                <SelectItem key={opt} value={opt} className="cursor-pointer focus:bg-gray-100 px-3 py-2 text-sm">
+                  {opt}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.yearsOfExperience && <p className="text-xs text-red-500">{errors.yearsOfExperience}</p>}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="bio" className="text-sm font-medium text-gray-700">Professional Bio</Label>
+          <textarea
+            id="bio"
+            value={data.bio}
+            onChange={(e) => setData({ ...data, bio: e.target.value })}
+            placeholder="Describe your skills, experience, and the type of work you do."
+            rows={5}
+            className={`w-full resize-none p-3 border rounded-lg text-sm focus:outline-none focus:border-[#605DEC] transition-colors ${errors.bio ? "border-red-400" : "border-gray-300 hover:border-gray-400"}`}
+          />
+          {errors.bio && <p className="text-xs text-red-500">{errors.bio}</p>}
+        </div>
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-5 py-2 rounded-lg bg-[#605DEC] text-white text-sm font-medium hover:bg-[#5558e3] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? "Saving…" : "Save Changes"}
+          </button>
+          {saved && (
+            <span className="flex items-center gap-1.5 text-sm text-green-600">
+              <CheckCircle className="w-4 h-4" /> Saved
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  )
+}


### PR DESCRIPTION
- Add ProfileIdentitySection with name, email, phone fields
- Add ProfileSkillsSection with skill category, experience, bio fields
- Add ProfileLocationSection with state, city, address fields
- Each section has inline validation and save confirmation state
- Add /artisan/profile page composing all three sections

Closes #92

# 🚀 Artisyn.io Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [ ] Closes #
- [ ] Added tests (if necessary)
- [ ] Run tests
- [ ] Run formatting
- [ ] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

---

## 📸 Evidence (A photo is required as evidence)

---

Thank you for contributing to Artisyn.io, we are glad that you have chosen us as your project of choice and we hope that you continue to contribute to this great project, so that together we can make our mark at the top!
