### PR TITLE
feat(frontend): add review summary and list components

### DIFF
--- a/src/components/reviews/review-list.tsx
+++ b/src/components/reviews/review-list.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type ReviewRating = 1 | 2 | 3 | 4 | 5;
+
+export interface Review {
+	id: string;
+	rating: ReviewRating;
+	comment: string;
+	createdAt: string | Date;
+	reviewerName: string;
+	artisanName?: string;
+	artisanId?: string;
+}
+
+export interface ReviewListProps {
+	reviews: Review[] | undefined;
+	isLoading?: boolean;
+	pageSize?: number;
+	className?: string;
+	emptyMessage?: string;
+}
+
+function clampNumber(value: number, min: number, max: number) {
+	if (Number.isNaN(value)) return min;
+	return Math.min(max, Math.max(min, value));
+}
+
+function formatDate(value: string | Date) {
+	const date = typeof value === "string" ? new Date(value) : value;
+	if (!(date instanceof Date) || Number.isNaN(date.getTime())) return "";
+	return new Intl.DateTimeFormat(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	}).format(date);
+}
+
+function initials(name: string) {
+	const parts = name.trim().split(/\s+/).filter(Boolean);
+	const first = parts[0]?.[0] ?? "?";
+	const last = parts.length > 1 ? parts[parts.length - 1]?.[0] : "";
+	return (first + last).toUpperCase();
+}
+
+function Stars({ rating }: { rating: ReviewRating }) {
+	return (
+		<div className="flex items-center gap-1" aria-label={`${rating} out of 5`}>
+			{Array.from({ length: 5 }).map((_, i) => {
+				const filled = i + 1 <= rating;
+				return (
+					<Star
+						key={i}
+						className={cn(
+							"h-4 w-4",
+							filled ? "fill-yellow-500 text-yellow-500" : "text-slate-300"
+						)}
+						aria-hidden="true"
+					/>
+				);
+			})}
+		</div>
+	);
+}
+
+function ReviewCard({ review }: { review: Review }) {
+	return (
+		<article className="rounded-lg border border-slate-200 bg-white p-5">
+			<header className="flex items-start justify-between gap-4">
+				<div className="flex items-center gap-3">
+					<div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-sm font-semibold text-slate-700">
+						{initials(review.reviewerName)}
+					</div>
+					<div className="min-w-0">
+						<div className="truncate font-medium text-slate-900">
+							{review.reviewerName}
+						</div>
+						<div className="text-xs text-slate-500">
+							{formatDate(review.createdAt)}
+							{review.artisanName ? (
+								<>
+									<span aria-hidden="true"> • </span>
+									<span className="text-slate-600">
+										for <span className="font-medium">{review.artisanName}</span>
+									</span>
+								</>
+							) : null}
+						</div>
+					</div>
+				</div>
+
+				<Stars rating={review.rating} />
+			</header>
+
+			<p className="mt-4 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+				{review.comment}
+			</p>
+		</article>
+	);
+}
+
+function ReviewCardSkeleton() {
+	return (
+		<div className="rounded-lg border border-slate-200 bg-white p-5">
+			<div className="flex items-start justify-between gap-4">
+				<div className="flex items-center gap-3">
+					<div className="h-10 w-10 rounded-full bg-slate-200" />
+					<div className="space-y-2">
+						<div className="h-4 w-40 rounded bg-slate-200" />
+						<div className="h-3 w-24 rounded bg-slate-200" />
+					</div>
+				</div>
+				<div className="h-4 w-24 rounded bg-slate-200" />
+			</div>
+			<div className="mt-4 space-y-2">
+				<div className="h-3 w-full rounded bg-slate-200" />
+				<div className="h-3 w-11/12 rounded bg-slate-200" />
+				<div className="h-3 w-8/12 rounded bg-slate-200" />
+			</div>
+		</div>
+	);
+}
+
+export function ReviewList({
+	reviews,
+	isLoading,
+	pageSize = 5,
+	className,
+	emptyMessage = "No reviews yet.",
+}: ReviewListProps) {
+	const safePageSize = clampNumber(pageSize, 1, 50);
+	const items = reviews ?? [];
+
+	const [page, setPage] = useState(1);
+	const totalPages = Math.max(1, Math.ceil(items.length / safePageSize));
+
+	useEffect(() => {
+		setPage((current) => clampNumber(current, 1, totalPages));
+	}, [items.length, safePageSize, totalPages]);
+
+	const paged = useMemo(() => {
+		const start = (page - 1) * safePageSize;
+		return items.slice(start, start + safePageSize);
+	}, [items, page, safePageSize]);
+
+	if (isLoading) {
+		return (
+			<section
+				className={cn("space-y-4", className)}
+				aria-busy="true"
+				aria-live="polite"
+			>
+				{Array.from({ length: 3 }).map((_, i) => (
+					<div key={i} className="animate-pulse">
+						<ReviewCardSkeleton />
+					</div>
+				))}
+			</section>
+		);
+	}
+
+	if (items.length === 0) {
+		return (
+			<section className={cn("rounded-lg border border-slate-200 bg-white p-6", className)}>
+				<p className="text-sm text-slate-600">{emptyMessage}</p>
+			</section>
+		);
+	}
+
+	return (
+		<section className={cn("space-y-4", className)}>
+			{paged.map((review) => (
+				<ReviewCard key={review.id} review={review} />
+			))}
+
+			{totalPages > 1 && (
+				<div className="flex items-center justify-between gap-3 pt-2">
+					<Button
+						variant="outline"
+						onClick={() => setPage((p) => Math.max(1, p - 1))}
+						disabled={page <= 1}
+					>
+						Prev
+					</Button>
+
+					<div className="text-sm tabular-nums text-slate-600">
+						Page {page} of {totalPages}
+					</div>
+
+					<Button
+						variant="outline"
+						onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+						disabled={page >= totalPages}
+					>
+						Next
+					</Button>
+				</div>
+			)}
+		</section>
+	);
+}

--- a/src/components/reviews/review-list.tsx
+++ b/src/components/reviews/review-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -123,19 +123,16 @@ export function ReviewList({
 	emptyMessage = "No reviews yet.",
 }: ReviewListProps) {
 	const safePageSize = clampNumber(pageSize, 1, 50);
-	const items = reviews ?? [];
+	const items = useMemo(() => reviews ?? [], [reviews]);
 
 	const [page, setPage] = useState(1);
 	const totalPages = Math.max(1, Math.ceil(items.length / safePageSize));
-
-	useEffect(() => {
-		setPage((current) => clampNumber(current, 1, totalPages));
-	}, [items.length, safePageSize, totalPages]);
+	const currentPage = clampNumber(page, 1, totalPages);
 
 	const paged = useMemo(() => {
-		const start = (page - 1) * safePageSize;
+		const start = (currentPage - 1) * safePageSize;
 		return items.slice(start, start + safePageSize);
-	}, [items, page, safePageSize]);
+	}, [currentPage, items, safePageSize]);
 
 	if (isLoading) {
 		return (
@@ -171,20 +168,20 @@ export function ReviewList({
 				<div className="flex items-center justify-between gap-3 pt-2">
 					<Button
 						variant="outline"
-						onClick={() => setPage((p) => Math.max(1, p - 1))}
-						disabled={page <= 1}
+						onClick={() => setPage(Math.max(1, currentPage - 1))}
+						disabled={currentPage <= 1}
 					>
 						Prev
 					</Button>
 
 					<div className="text-sm tabular-nums text-slate-600">
-						Page {page} of {totalPages}
+						Page {currentPage} of {totalPages}
 					</div>
 
 					<Button
 						variant="outline"
-						onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-						disabled={page >= totalPages}
+						onClick={() => setPage(Math.min(totalPages, currentPage + 1))}
+						disabled={currentPage >= totalPages}
 					>
 						Next
 					</Button>

--- a/src/components/reviews/review-list.tsx
+++ b/src/components/reviews/review-list.tsx
@@ -13,8 +13,6 @@ export interface Review {
 	comment: string;
 	createdAt: string | Date;
 	reviewerName: string;
-	artisanName?: string;
-	artisanId?: string;
 }
 
 export interface ReviewListProps {
@@ -81,14 +79,6 @@ function ReviewCard({ review }: { review: Review }) {
 						</div>
 						<div className="text-xs text-slate-500">
 							{formatDate(review.createdAt)}
-							{review.artisanName ? (
-								<>
-									<span aria-hidden="true"> • </span>
-									<span className="text-slate-600">
-										for <span className="font-medium">{review.artisanName}</span>
-									</span>
-								</>
-							) : null}
 						</div>
 					</div>
 				</div>

--- a/src/components/reviews/review-summary.tsx
+++ b/src/components/reviews/review-summary.tsx
@@ -1,0 +1,155 @@
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Rating = 1 | 2 | 3 | 4 | 5;
+
+export interface ReviewSummaryProps {
+	averageRating: number;
+	totalCount: number;
+	ratingCounts: Partial<Record<Rating, number>>;
+	className?: string;
+	isLoading?: boolean;
+}
+
+function clampNumber(value: number, min: number, max: number) {
+	if (Number.isNaN(value)) return min;
+	return Math.min(max, Math.max(min, value));
+}
+
+function safeCount(value: unknown) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
+	return Math.floor(value);
+}
+
+function StarRow({ value }: { value: number }) {
+	const clamped = clampNumber(value, 0, 5);
+
+	return (
+		<div className="flex items-center gap-1" aria-label={`Rating ${clamped} out of 5`}>
+			{Array.from({ length: 5 }).map((_, index) => {
+				const starIndex = index + 1;
+				const fill = clampNumber(clamped - (starIndex - 1), 0, 1);
+				const fillPct = `${Math.round(fill * 100)}%`;
+
+				return (
+					<span key={starIndex} className="relative inline-block h-5 w-5">
+						<Star className="h-5 w-5 text-slate-300" aria-hidden="true" />
+						<span
+							className="absolute inset-0 overflow-hidden"
+							style={{ width: fillPct }}
+							aria-hidden="true"
+						>
+							<Star className="h-5 w-5 fill-yellow-500 text-yellow-500" />
+						</span>
+					</span>
+				);
+			})}
+		</div>
+	);
+}
+
+function Skeleton() {
+	return (
+		<div className="animate-pulse">
+			<div className="grid gap-6 md:grid-cols-2">
+				<div className="space-y-3">
+					<div className="h-10 w-24 rounded bg-slate-200" />
+					<div className="h-5 w-32 rounded bg-slate-200" />
+					<div className="h-4 w-24 rounded bg-slate-200" />
+				</div>
+				<div className="space-y-2">
+					{Array.from({ length: 5 }).map((_, i) => (
+						<div key={i} className="flex items-center gap-3">
+							<div className="h-4 w-6 rounded bg-slate-200" />
+							<div className="h-2 flex-1 rounded bg-slate-200" />
+							<div className="h-4 w-8 rounded bg-slate-200" />
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function ReviewSummary({
+	averageRating,
+	totalCount,
+	ratingCounts,
+	className,
+	isLoading,
+}: ReviewSummaryProps) {
+	if (isLoading) {
+		return (
+			<section
+				className={cn("rounded-lg border border-slate-200 bg-white p-6", className)}
+				aria-busy="true"
+			>
+				<Skeleton />
+			</section>
+		);
+	}
+
+	const safeTotal = safeCount(totalCount);
+	const average = clampNumber(averageRating, 0, 5);
+
+	const counts: Record<Rating, number> = {
+		5: safeCount(ratingCounts?.[5]),
+		4: safeCount(ratingCounts?.[4]),
+		3: safeCount(ratingCounts?.[3]),
+		2: safeCount(ratingCounts?.[2]),
+		1: safeCount(ratingCounts?.[1]),
+	};
+
+	return (
+		<section
+			className={cn("rounded-lg border border-slate-200 bg-white p-6", className)}
+		>
+			<div className="grid gap-6 md:grid-cols-2">
+				<div className="space-y-2">
+					<div className="flex items-end gap-3">
+						<div className="text-4xl font-semibold tracking-tight text-slate-900">
+							{average.toFixed(1)}
+						</div>
+						<div className="pb-1">
+							<StarRow value={average} />
+						</div>
+					</div>
+
+					{safeTotal === 0 ? (
+						<p className="text-sm text-slate-600">No reviews yet</p>
+					) : (
+						<p className="text-sm text-slate-600">
+							{safeTotal.toLocaleString()} review{safeTotal === 1 ? "" : "s"}
+						</p>
+					)}
+				</div>
+
+				<div className="space-y-2">
+					{([5, 4, 3, 2, 1] as const).map((rating) => {
+						const count = counts[rating];
+						const ratio = safeTotal > 0 ? clampNumber(count / safeTotal, 0, 1) : 0;
+
+						return (
+							<div key={rating} className="flex items-center gap-3">
+								<div className="flex w-10 items-center gap-1 text-sm text-slate-700">
+									<span className="tabular-nums">{rating}</span>
+									<Star className="h-4 w-4 fill-yellow-500 text-yellow-500" />
+								</div>
+								<div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100">
+									<div
+										className="h-full rounded-full bg-yellow-500"
+										style={{ width: `${Math.round(ratio * 100)}%` }}
+									/>
+								</div>
+								<div className="w-10 text-right text-sm tabular-nums text-slate-600">
+									{count}
+								</div>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</section>
+	);
+}
+


### PR DESCRIPTION
# 🚀 Artisyn.io Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #73
- [ ] Added tests (if necessary)
- [ ] Run tests
- [x] Run formatting
- [x] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

Added reusable review components for the upcoming public artisan profile route:

- `ReviewSummary`: shows average rating, total reviews count, and 5→1 rating distribution bars (with loading skeleton support).
- `ReviewList`: renders paginated review cards with loading and empty states.

Files:
- `src/components/reviews/review-summary.tsx`
- `src/components/reviews/review-list.tsx`

---

## 📸 Evidence (A photo is required as evid
<img width="2560" height="1440" alt="Screenshot from 2026-05-31 07-34-29" src="https://github.com/user-attachments/assets/7e6aa006-16f4-49d3-b312-778f50a1c7e9" />

Attache creenshot showing:
- Review summary (average + distribution bars)
- Review list (with pagination)