### PR TITLE
feat(frontend): implement active jobs tab

### DIFF
--- a/src/app/(dashboard)/artisan/listings/(components)/TabPages.tsx
+++ b/src/app/(dashboard)/artisan/listings/(components)/TabPages.tsx
@@ -1,14 +1,59 @@
 "use client";
 
-import { useState, Suspense } from "react"; 
+import { useState, Suspense } from "react";
 import JobCard from "./JobCard";
 import AppliedJobsList from "./AppliedJobsList";
+import { jobs } from "../dummyjobs";
+import Image from "next/image";
+import bgImg from "../(assets)/bg.png";
 
 const EmptyState = ({ text }: { text: string }) => (
   <div className="py-20 text-center text-sm text-gray-500">
     {text}
   </div>
 );
+
+const ActiveJobCard = () => {
+  const activeJobs = jobs.filter((job) => job.status === "active");
+
+  if (activeJobs.length === 0) {
+    return <EmptyState text="No active jobs yet." />;
+  }
+
+  return (
+    <div className="mt-8">
+      {activeJobs.map((info, index) => (
+        <div key={index} className="flex mb-4 lg:flex-row md:flex-row flex-col">
+          <div className="lg:w-[12%] md:w-[20%] w-full lg:mr-6 md:mr-4 mr-0">
+            <Image src={bgImg} alt="" width={200} height={200} className="w-full" />
+          </div>
+          <div className="lg:w-[70%] md:w-[70%] w-full flex flex-col lg:my-0 md:my-0 my-3">
+            <div className="flex lg:justify-between lg:items-center md:justify-between md:items-center lg:flex-row md:flex-row flex-col">
+              <div>
+                <p className="text-[12px] text-[#212121]">In Progress</p>
+                <h2 className="lg:text-[20px] md:text-[18px] text-[16px] font-semibold">
+                  {info.shortDescription}
+                </h2>
+              </div>
+              <span className="border rounded-md py-2 text-[14px] px-6 lg:my-0 md:my-0 my-3 text-green-600 border-green-600">
+                Active
+              </span>
+            </div>
+            <div className="text-[14px] flex justify-between lg:items-center md:items-center mt-auto text-[#777679] flex-col lg:flex-row md:flex-row">
+              <p>Category: {info.category} <span className="mx-4">|</span></p>
+              <p>Compensation: {info.budget} <span className="mx-4">|</span></p>
+              <p>Location: {info.location} <span className="mx-4">|</span></p>
+              <p>
+                Urgency:{" "}
+                <span className="uppercase text-red-500">{info.urgency}</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
 
 const TabPages = () => {
   const [activeTab, setActiveTab] = useState("available");
@@ -46,12 +91,12 @@ const TabPages = () => {
         </div>
       </div>
       <div className="mt-4">
-     {activeTab === "available" && (
+        {activeTab === "available" && (
           <Suspense fallback={<p className="text-center text-sm text-gray-400 py-10">Loading jobs...</p>}>
             <JobCard />
           </Suspense>
-          )}
-        {activeTab === "active" && <EmptyState text="No active jobs yet." />}
+        )}
+        {activeTab === "active" && <ActiveJobCard />}
         {activeTab === "applied" && <AppliedJobsList />}
         {activeTab === "completed" && <EmptyState text="No completed jobs yet." />}
       </div>

--- a/src/app/(dashboard)/artisan/listings/dummyjobs.ts
+++ b/src/app/(dashboard)/artisan/listings/dummyjobs.ts
@@ -6,6 +6,7 @@ export interface Job {
   shortDescription: string;
   urgency: "low" | "medium" | "high";
   icon: string;
+  status: "available" | "active" | "applied" | "completed";
 }
 
 export const jobs: Job[] = [
@@ -18,6 +19,7 @@ export const jobs: Job[] = [
       "Fix leaking pipes and replace damaged bathroom fittings in a residential apartment.",
     urgency: "high",
     icon: "FiTool",
+    status: "available",
   },
   {
     title: "Tailor",
@@ -28,6 +30,7 @@ export const jobs: Job[] = [
       "Sew a complete set of custom native attire for an upcoming family event.",
     urgency: "medium",
     icon: "FiScissors",
+    status: "active",
   },
   {
     title: "Mechanic",
@@ -38,6 +41,7 @@ export const jobs: Job[] = [
       "Diagnose engine knocking sound and service a Toyota Corolla.",
     urgency: "high",
     icon: "FiTruck",
+    status: "active",
   },
   {
     title: "Electrician",
@@ -48,6 +52,7 @@ export const jobs: Job[] = [
       "Fix faulty wiring and install new power sockets in a two-bedroom flat.",
     urgency: "low",
     icon: "FiZap",
+    status: "available",
   },
   {
     title: "Barber",
@@ -58,6 +63,7 @@ export const jobs: Job[] = [
       "Provide haircuts, beard trims, and grooming services for clients in a professional setting.",
     urgency: "medium",
     icon: "FiScissors",
+    status: "applied",
   },
   {
     title: "Teacher",
@@ -68,5 +74,6 @@ export const jobs: Job[] = [
       "Teach students literacy, numeracy, and other subjects at a local school.",
     urgency: "low",
     icon: "FiBriefcase",
+    status: "completed",
   },
 ];


### PR DESCRIPTION
## Summary

Integrates the active jobs tab with jobs filtered by active status.

- Added `status` field (`available | active | applied | completed`) to the `Job` interface in `dummyjobs.ts`
- Seeded existing jobs with appropriate status values
- Implemented `ActiveJobCard` component in `TabPages.tsx` that filters jobs by `status === "active"` and renders them with status labels
- Preserved upstream changes: `Suspense` wrapper on available tab and `AppliedJobsList` on applied tab
- Active tab now shows in-progress jobs instead of an empty state

closes #86