### PR TITLE
Frontend/artisan onboarding api

### DIFF
--- a/src/app/(auth)/profile-setup/page.tsx
+++ b/src/app/(auth)/profile-setup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { AccountTypeSelection } from "@/components/artisan/account-type-selection";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArtisanProfileStep1 } from "@/components/artisan/artisan-profile-step1";
@@ -171,11 +171,13 @@ export default function Page() {
 
   const handleArtisanStep2Complete = async (data: Partial<ArtisanFormData>) => {
 
+    // Return if app is already in loading state.
     if(isLoading) return;
 
+    // Use merged local object to handle async React state updates.
     const updatedArtisanData = {...artisanData, ...data};
-    setArtisanData(updatedArtisanData);
 
+    setArtisanData(updatedArtisanData);
     setIsLoading(true);
 
     try {

--- a/src/app/(auth)/profile-setup/page.tsx
+++ b/src/app/(auth)/profile-setup/page.tsx
@@ -80,6 +80,7 @@ export default function Page() {
   const [artisanData, setArtisanData] = useState<ArtisanFormData>(
     initialState.artisanData,
   );
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   // Save state whenever it changes
   useEffect(() => {
@@ -168,11 +169,52 @@ export default function Page() {
     setCurrentStep("artisan-step2");
   };
 
-  const handleArtisanStep2Complete = (data: Partial<ArtisanFormData>) => {
-    setArtisanData((prev) => ({ ...prev, ...data }));
-    setCurrentStep("success");
-    if (typeof window !== "undefined") {
-      localStorage.removeItem("artisan-onboarding-state");
+  const handleArtisanStep2Complete = async (data: Partial<ArtisanFormData>) => {
+
+    if(isLoading) return;
+
+    const updatedArtisanData = {...artisanData, ...data};
+    setArtisanData(updatedArtisanData);
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch('/api/profile', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updatedArtisanData),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || 'Failed to save profile data.');
+      }
+
+      const responseData = await response.json();
+      console.log('Profile saved successfully:', responseData);
+
+      if (typeof window !== "undefined") {
+        localStorage.removeItem("artisan-onboarding-state");
+      }
+
+      setCurrentStep("success");
+
+      setTimeout(() => {
+        setArtisanData(initialState.artisanData);
+      }, 2000);
+
+    } catch (error) {
+      console.error('Error saving profile data:', error);
+      const errorMessage = error instanceof Error 
+        ? error.message 
+        : 'An error occurred while saving profile data to server. Please try again.';
+      
+        console.error("Error message:", errorMessage);
+
+    } finally {
+      setIsLoading(false);
     }
   };
 


### PR DESCRIPTION
# 🚀 Artisyn.io Pull Request

- [x] Closes #103 
- [ ] Added tests (IF NECESSARY)
- [ ] Run tests
- [x] Run formatting
- [x] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

- Replaced local-only onboarding persistence with API submission
- Combined onboarding step payloads before submission
- Preserved local draft state as a transient backup during failed submissions.
- Cleared local onboarding draft only after successful profile persistence.
- Added defensive async state handling to avoid stale React state during submission.
- Added error handling for transient request/network failures. Onboarding progress is preserved locally for retry attempts.
- Prevented duplicate submissions during active loading state.
---

## Notes

- Changes are intentionally scoped to `profile-setup/page.tsx` and no direct coupling is made between component page and backend. The profile-setup flow is ready to be integrated into frontend API abstraction.
---

## 📸 Evidence 

<img width="1430" height="958" alt="image" src="https://github.com/user-attachments/assets/922f0cb5-eca5-4a9d-aef2-5d889d10ff9e" />

---

Tags: STELLAR WAVE
