### PR TITLE
feat(frontend): add route error boundaries

### DIFF
--- a/src/app/(auth)/error.tsx
+++ b/src/app/(auth)/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+
+type AuthRouteErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function AuthRouteError({
+  error,
+  reset,
+}: AuthRouteErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 px-6 py-16">
+      <div className="w-full max-w-md rounded-3xl border border-border bg-background p-8 text-center shadow-sm">
+        <p className="text-sm font-medium uppercase tracking-[0.24em] text-muted-foreground">
+          Auth Error
+        </p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-foreground">
+          We hit a snag loading this page.
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          Please try again. If the problem continues, you can go back and retry
+          the last step.
+        </p>
+        <Button className="mt-6 w-full" onClick={reset}>
+          Try Again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+
+type DashboardRouteErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function DashboardRouteError({
+  error,
+  reset,
+}: DashboardRouteErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
+      <div className="w-full max-w-2xl rounded-3xl border border-border bg-background p-8 shadow-sm">
+        <p className="text-sm font-medium uppercase tracking-[0.24em] text-muted-foreground">
+          Dashboard Error
+        </p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-foreground">
+          This section ran into a problem.
+        </h1>
+        <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
+          Your navigation is still available, and you can retry loading this
+          view without leaving the dashboard.
+        </p>
+        <Button className="mt-6" onClick={reset}>
+          Retry
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 🚀 Artisyn.io Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [ ] Closes #64
- [ ] Added tests (if necessary)
- [x] Run tests
- [ ] Run formatting
- [ ] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

Added route-level error boundaries for the primary App Router groups:
- `src/app/(auth)/error.tsx`
- `src/app/(dashboard)/error.tsx`

These custom error boundaries prevent blank failure screens when runtime errors occur in those route groups. Each boundary shows a user-friendly fallback UI and includes a retry action using Next.js' `reset()` callback so users can recover without losing overall navigation.

---

## 📸 Evidence (A photo is required as evidence)

Attach screenshots showing:
1. An error rendered inside the auth route with the custom fallback UI
2. An error rendered inside the dashboard route with the retry button visible