### PR TITLE
Frontend/search filter sidebar

### DIFF
--- a/src/app/(auth)/error.tsx
+++ b/src/app/(auth)/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+
+type AuthRouteErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function AuthRouteError({
+  error,
+  reset,
+}: AuthRouteErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 px-6 py-16">
+      <div className="w-full max-w-md rounded-3xl border border-border bg-background p-8 text-center shadow-sm">
+        <p className="text-sm font-medium uppercase tracking-[0.24em] text-muted-foreground">
+          Auth Error
+        </p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-foreground">
+          We hit a snag loading this page.
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          Please try again. If the problem continues, you can go back and retry
+          the last step.
+        </p>
+        <Button className="mt-6 w-full" onClick={reset}>
+          Try Again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+
+type DashboardRouteErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function DashboardRouteError({
+  error,
+  reset,
+}: DashboardRouteErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
+      <div className="w-full max-w-2xl rounded-3xl border border-border bg-background p-8 shadow-sm">
+        <p className="text-sm font-medium uppercase tracking-[0.24em] text-muted-foreground">
+          Dashboard Error
+        </p>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-foreground">
+          This section ran into a problem.
+        </h1>
+        <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
+          Your navigation is still available, and you can retry loading this
+          view without leaving the dashboard.
+        </p>
+        <Button className="mt-6" onClick={reset}>
+          Retry
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components-preview/search-controls/page.tsx
+++ b/src/app/components-preview/search-controls/page.tsx
@@ -2,6 +2,10 @@
 
 import { useMemo, useState } from "react";
 
+import {
+  FilterSidebar,
+  type SearchFilterValue,
+} from "@/components/search/filter-sidebar";
 import { PaginationControl } from "@/components/search/pagination-control";
 import {
   ARTISAN_SEARCH_SORT_OPTIONS,
@@ -10,21 +14,108 @@ import {
 } from "@/components/search/sort-control";
 
 const previewArtisans = [
-  { name: "James Emeka", category: "Plumber", rating: 4.9, price: 45 },
-  { name: "Jane Smith", category: "Barber", rating: 4.8, price: 30 },
-  { name: "Grace Fixer", category: "Painter", rating: 4.7, price: 55 },
-  { name: "Amara Chike", category: "Electrician", rating: 4.6, price: 60 },
-  { name: "Sofia Okafor", category: "Chef", rating: 4.9, price: 75 },
-  { name: "John Doe", category: "Cleaner", rating: 4.5, price: 25 },
-  { name: "Tunde Bello", category: "Carpenter", rating: 4.4, price: 50 },
-  { name: "Mina Adebayo", category: "Tailor", rating: 4.8, price: 40 },
-  { name: "Kelvin Obi", category: "Mechanic", rating: 4.3, price: 65 },
-  { name: "Ada Nwosu", category: "Tech Repair", rating: 4.7, price: 70 },
-  { name: "Femi Cole", category: "Plumber", rating: 4.2, price: 35 },
-  { name: "Ife Martins", category: "Painter", rating: 4.6, price: 48 },
+  {
+    name: "James Emeka",
+    category: "Plumber",
+    location: "Ikeja, Lagos",
+    price: 45,
+    rating: 4.9,
+    verified: true,
+  },
+  {
+    name: "Jane Smith",
+    category: "Barber",
+    location: "Yaba, Lagos",
+    price: 30,
+    rating: 4.8,
+    verified: false,
+  },
+  {
+    name: "Grace Fixer",
+    category: "Painter",
+    location: "Lekki, Lagos",
+    price: 55,
+    rating: 4.7,
+    verified: true,
+  },
+  {
+    name: "Amara Chike",
+    category: "Electrician",
+    location: "Abuja Municipal, Abuja",
+    price: 60,
+    rating: 4.6,
+    verified: true,
+  },
+  {
+    name: "Sofia Okafor",
+    category: "Chef",
+    location: "Surulere, Lagos",
+    price: 75,
+    rating: 4.9,
+    verified: false,
+  },
+  {
+    name: "John Doe",
+    category: "Cleaner",
+    location: "Ibadan North, Oyo",
+    price: 25,
+    rating: 4.5,
+    verified: false,
+  },
+  {
+    name: "Tunde Bello",
+    category: "Carpenter",
+    location: "Abeokuta, Ogun",
+    price: 50,
+    rating: 4.4,
+    verified: true,
+  },
+  {
+    name: "Mina Adebayo",
+    category: "Tailor",
+    location: "Victoria Island, Lagos",
+    price: 40,
+    rating: 4.8,
+    verified: true,
+  },
+  {
+    name: "Kelvin Obi",
+    category: "Mechanic",
+    location: "Gwarinpa, Abuja",
+    price: 65,
+    rating: 4.3,
+    verified: false,
+  },
+  {
+    name: "Ada Nwosu",
+    category: "Tech Repair",
+    location: "Enugu North, Enugu",
+    price: 70,
+    rating: 4.7,
+    verified: true,
+  },
+  {
+    name: "Femi Cole",
+    category: "Plumber",
+    location: "Ikorodu, Lagos",
+    price: 35,
+    rating: 4.2,
+    verified: false,
+  },
+  {
+    name: "Ife Martins",
+    category: "Painter",
+    location: "Port Harcourt, Rivers",
+    price: 48,
+    rating: 4.6,
+    verified: true,
+  },
 ];
 
 const PAGE_SIZE = 4;
+const PREVIEW_CATEGORIES = Array.from(
+  new Set(previewArtisans.map((artisan) => artisan.category))
+).sort((first, second) => first.localeCompare(second));
 
 function sortArtisans(
   artisans: typeof previewArtisans,
@@ -54,10 +145,35 @@ function sortArtisans(
 export default function ComponentsPreviewPage() {
   const [sortValue, setSortValue] = useState<SearchSortValue>("relevance");
   const [page, setPage] = useState(1);
+  const [filters, setFilters] = useState<SearchFilterValue>({});
+
+  const filteredArtisans = useMemo(() => {
+    return previewArtisans.filter((artisan) => {
+      const matchesCategory =
+        !filters.category || artisan.category === filters.category;
+      const matchesLocation =
+        !filters.location ||
+        artisan.location.toLowerCase().includes(filters.location.toLowerCase());
+      const matchesMinPrice =
+        filters.minPrice === undefined || artisan.price >= filters.minPrice;
+      const matchesMaxPrice =
+        filters.maxPrice === undefined || artisan.price <= filters.maxPrice;
+      const matchesVerification =
+        !filters.verifiedOnly || artisan.verified;
+
+      return (
+        matchesCategory &&
+        matchesLocation &&
+        matchesVerification &&
+        matchesMinPrice &&
+        matchesMaxPrice
+      );
+    });
+  }, [filters]);
 
   const sortedArtisans = useMemo(
-    () => sortArtisans(previewArtisans, sortValue),
-    [sortValue]
+    () => sortArtisans(filteredArtisans, sortValue),
+    [filteredArtisans, sortValue]
   );
   const totalPages = Math.ceil(sortedArtisans.length / PAGE_SIZE);
   const pagedArtisans = sortedArtisans.slice(
@@ -72,71 +188,100 @@ export default function ComponentsPreviewPage() {
 
   return (
     <main className="min-h-screen bg-[#F8FAFC] px-4 py-10 text-[#020817]">
-      <section className="mx-auto flex max-w-5xl flex-col gap-8">
-        <div>
-          <p className="text-sm font-medium text-[#605DEC]">
-            Components Preview
-          </p>
-          <h1 className="mt-2 text-3xl font-bold text-[#262626]">
-            Search Controls
-          </h1>
-        </div>
+      <section className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[320px_minmax(0,1fr)]">
+        <FilterSidebar
+          categories={PREVIEW_CATEGORIES}
+          onChange={setFilters}
+          title="Refine your artisan search"
+        />
 
-        <div className="flex flex-col gap-4 bg-white p-5">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <SortControl onSortChange={handleSortChange} value={sortValue} />
-            <div className="text-sm text-[#64748B]">
-              Active backend sort:{" "}
-              <span className="font-medium text-[#262626]">{sortValue}</span>
+        <div className="flex flex-col gap-8">
+          <div>
+            <p className="text-sm font-medium text-[#605DEC]">
+              Components Preview
+            </p>
+            <h1 className="mt-2 text-3xl font-bold text-[#262626]">
+              Search Controls
+            </h1>
+          </div>
+
+          <div className="flex flex-col gap-4 bg-white p-5">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <SortControl onSortChange={handleSortChange} value={sortValue} />
+              <div className="text-sm text-[#64748B]">
+                Active backend sort:{" "}
+                <span className="font-medium text-[#262626]">{sortValue}</span>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between text-sm text-[#64748B]">
+              <span>{filteredArtisans.length} results</span>
+              {filters.verifiedOnly ? (
+                <span className="rounded-full bg-[#EEF2FF] px-2.5 py-1 text-xs font-medium text-[#605DEC]">
+                  Verified only
+                </span>
+              ) : null}
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              {pagedArtisans.map((artisan) => (
+                <article
+                  className="rounded-lg border border-[#E2E8F0] p-4"
+                  key={`${artisan.name}-${artisan.category}`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h2 className="font-semibold text-[#262626]">
+                        {artisan.name}
+                      </h2>
+                      <p className="mt-1 text-sm text-[#64748B]">
+                        {artisan.category}
+                      </p>
+                    </div>
+                    <span className="rounded-full bg-[#EEF2FF] px-2.5 py-1 text-xs font-medium text-[#605DEC]">
+                      {artisan.rating.toFixed(1)}
+                    </span>
+                  </div>
+                  <p className="mt-4 text-sm text-[#475569]">
+                    {artisan.location}
+                  </p>
+                  <p className="mt-2 text-sm text-[#475569]">
+                    ${artisan.price}/hr
+                  </p>
+                </article>
+              ))}
+            </div>
+
+            <PaginationControl
+              currentPage={page}
+              onPageChange={setPage}
+              totalPages={totalPages}
+            />
+          </div>
+
+          <div className="bg-white p-5">
+            <h2 className="text-base font-semibold text-[#262626]">
+              Backend sort contract
+            </h2>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {ARTISAN_SEARCH_SORT_OPTIONS.map((option) => (
+                <span
+                  className="rounded-full bg-[#F1F5F9] px-3 py-1.5 text-sm text-[#475569]"
+                  key={option.value}
+                >
+                  {option.value}
+                </span>
+              ))}
             </div>
           </div>
 
-          <div className="grid gap-3 md:grid-cols-2">
-            {pagedArtisans.map((artisan) => (
-              <article
-                className="rounded-lg border border-[#E2E8F0] p-4"
-                key={`${artisan.name}-${artisan.category}`}
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <h2 className="font-semibold text-[#262626]">
-                      {artisan.name}
-                    </h2>
-                    <p className="mt-1 text-sm text-[#64748B]">
-                      {artisan.category}
-                    </p>
-                  </div>
-                  <span className="rounded-full bg-[#EEF2FF] px-2.5 py-1 text-xs font-medium text-[#605DEC]">
-                    {artisan.rating.toFixed(1)}
-                  </span>
-                </div>
-                <p className="mt-4 text-sm text-[#475569]">
-                  ${artisan.price}/hr
-                </p>
-              </article>
-            ))}
-          </div>
-
-          <PaginationControl
-            currentPage={page}
-            onPageChange={setPage}
-            totalPages={totalPages}
-          />
-        </div>
-
-        <div className="bg-white p-5">
-          <h2 className="text-base font-semibold text-[#262626]">
-            Backend sort contract
-          </h2>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {ARTISAN_SEARCH_SORT_OPTIONS.map((option) => (
-              <span
-                className="rounded-full bg-[#F1F5F9] px-3 py-1.5 text-sm text-[#475569]"
-                key={option.value}
-              >
-                {option.value}
-              </span>
-            ))}
+          <div className="bg-white p-5">
+            <h2 className="text-base font-semibold text-[#262626]">
+              Emitted filter payload
+            </h2>
+            <pre className="mt-4 overflow-x-auto rounded-2xl bg-[#F8FAFC] p-4 text-sm text-[#475569]">
+              {JSON.stringify(filters, null, 2)}
+            </pre>
           </div>
         </div>
       </section>

--- a/src/components/search/filter-sidebar.tsx
+++ b/src/components/search/filter-sidebar.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+export type SearchFilterValue = {
+  category?: string;
+  location?: string;
+  maxPrice?: number;
+  minPrice?: number;
+  verifiedOnly?: boolean;
+};
+
+type SearchFilterDraft = {
+  category: string;
+  location: string;
+  maxPrice: string;
+  minPrice: string;
+  verifiedOnly: boolean;
+};
+
+type FilterSidebarProps = {
+  categories?: string[];
+  className?: string;
+  initialValue?: Partial<SearchFilterValue>;
+  onChange: (filters: SearchFilterValue) => void;
+  title?: string;
+};
+
+const DEFAULT_CATEGORY_VALUE = "all-categories";
+
+function toDraft(value?: Partial<SearchFilterValue>): SearchFilterDraft {
+  return {
+    category: value?.category ?? "",
+    location: value?.location ?? "",
+    maxPrice:
+      typeof value?.maxPrice === "number" ? String(value.maxPrice) : "",
+    minPrice:
+      typeof value?.minPrice === "number" ? String(value.minPrice) : "",
+    verifiedOnly: value?.verifiedOnly ?? false,
+  };
+}
+
+function parsePrice(value: string) {
+  const normalizedValue = value.trim();
+
+  if (normalizedValue.length === 0) {
+    return undefined;
+  }
+
+  const parsedValue = Number(normalizedValue);
+
+  if (!Number.isFinite(parsedValue)) {
+    return undefined;
+  }
+
+  return Math.max(parsedValue, 0);
+}
+
+export function normalizeSearchFilters(
+  draft: SearchFilterDraft
+): SearchFilterValue {
+  const category = draft.category.trim();
+  const location = draft.location.trim();
+  const parsedMinPrice = parsePrice(draft.minPrice);
+  const parsedMaxPrice = parsePrice(draft.maxPrice);
+  const minPrice =
+    parsedMinPrice !== undefined &&
+    parsedMaxPrice !== undefined &&
+    parsedMinPrice > parsedMaxPrice
+      ? parsedMaxPrice
+      : parsedMinPrice;
+  const maxPrice =
+    parsedMinPrice !== undefined &&
+    parsedMaxPrice !== undefined &&
+    parsedMinPrice > parsedMaxPrice
+      ? parsedMinPrice
+      : parsedMaxPrice;
+
+  return {
+    category: category || undefined,
+    location: location || undefined,
+    maxPrice,
+    minPrice,
+    verifiedOnly: draft.verifiedOnly || undefined,
+  };
+}
+
+export function FilterSidebar({
+  categories = [],
+  className,
+  initialValue,
+  onChange,
+  title = "Filter artisans",
+}: FilterSidebarProps) {
+  const [draft, setDraft] = useState<SearchFilterDraft>(() =>
+    toDraft(initialValue)
+  );
+
+  const normalizedFilters = useMemo(
+    () => normalizeSearchFilters(draft),
+    [draft]
+  );
+
+  useEffect(() => {
+    onChange(normalizedFilters);
+  }, [normalizedFilters, onChange]);
+
+  const handleFieldChange = (
+    field: keyof SearchFilterDraft,
+    nextValue: SearchFilterDraft[keyof SearchFilterDraft]
+  ) => {
+    setDraft((currentDraft) => ({
+      ...currentDraft,
+      [field]: nextValue,
+    }));
+  };
+
+  const resetFilters = () => {
+    setDraft(toDraft());
+  };
+
+  return (
+    <aside
+      className={cn(
+        "w-full rounded-3xl border border-[#E2E8F0] bg-white p-6 shadow-sm",
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-[#605DEC]">Search Filters</p>
+          <h2 className="mt-1 text-xl font-semibold text-[#020817]">{title}</h2>
+        </div>
+        <Button
+          className="rounded-xl border-[#E2E8F0] text-[#475569]"
+          onClick={resetFilters}
+          type="button"
+          variant="outline"
+        >
+          Reset
+        </Button>
+      </div>
+
+      <div className="mt-6 space-y-6">
+        <div className="space-y-2">
+          <Label className="text-sm font-medium text-[#334155]" htmlFor="category">
+            Category
+          </Label>
+          <Select
+            onValueChange={(nextValue) =>
+              handleFieldChange(
+                "category",
+                nextValue === DEFAULT_CATEGORY_VALUE ? "" : nextValue
+              )
+            }
+            value={draft.category || DEFAULT_CATEGORY_VALUE}
+          >
+            <SelectTrigger
+              aria-label="Category"
+              className="h-11 rounded-xl border-[#E2E8F0] bg-white text-[#020817]"
+              id="category"
+            >
+              <SelectValue placeholder="Select a category" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={DEFAULT_CATEGORY_VALUE}>All categories</SelectItem>
+              {categories.map((category) => (
+                <SelectItem key={category} value={category}>
+                  {category}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-medium text-[#334155]" htmlFor="location">
+            Location
+          </Label>
+          <Input
+            className="h-11 rounded-xl border-[#E2E8F0] bg-white text-[#020817]"
+            id="location"
+            onChange={(event) => handleFieldChange("location", event.target.value)}
+            placeholder="City or area"
+            value={draft.location}
+          />
+        </div>
+
+        <div className="space-y-3">
+          <Label className="text-sm font-medium text-[#334155]" htmlFor="verified-only">
+            Verification
+          </Label>
+          <label
+            className="flex items-center gap-3 rounded-2xl border border-[#E2E8F0] px-4 py-3 text-sm text-[#334155]"
+            htmlFor="verified-only"
+          >
+            <input
+              checked={draft.verifiedOnly}
+              className="size-4 rounded border-[#CBD5E1] text-[#605DEC] accent-[#605DEC]"
+              id="verified-only"
+              onChange={(event) =>
+                handleFieldChange("verifiedOnly", event.target.checked)
+              }
+              type="checkbox"
+            />
+            Show verified artisans only
+          </label>
+        </div>
+
+        <div className="space-y-3">
+          <Label className="text-sm font-medium text-[#334155]">Price range</Label>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label
+                className="text-xs font-medium uppercase tracking-[0.16em] text-[#64748B]"
+                htmlFor="min-price"
+              >
+                Minimum
+              </Label>
+              <Input
+                className="h-11 rounded-xl border-[#E2E8F0] bg-white text-[#020817]"
+                id="min-price"
+                inputMode="numeric"
+                min={0}
+                onChange={(event) =>
+                  handleFieldChange("minPrice", event.target.value)
+                }
+                placeholder="0"
+                type="number"
+                value={draft.minPrice}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label
+                className="text-xs font-medium uppercase tracking-[0.16em] text-[#64748B]"
+                htmlFor="max-price"
+              >
+                Maximum
+              </Label>
+              <Input
+                className="h-11 rounded-xl border-[#E2E8F0] bg-white text-[#020817]"
+                id="max-price"
+                inputMode="numeric"
+                min={0}
+                onChange={(event) =>
+                  handleFieldChange("maxPrice", event.target.value)
+                }
+                placeholder="250"
+                type="number"
+                value={draft.maxPrice}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
# 🚀 Artisyn.io Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [ ] Closes #66
- [ ] Added tests (if necessary)
- [x] Run tests
- [ ] Run formatting
- [ ] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

Added a reusable search filter sidebar component for artisan discovery at `src/components/search/filter-sidebar.tsx`.

The component exposes an `onChange` callback that emits a normalized filter object to the parent and supports:
- category
- location
- verification
- price range

Also updated the search controls preview page to render the new sidebar and display the emitted filter payload for easier validation and reuse.

---

## 📸 Evidence (A photo is required as evidence)

Attach a screenshot of `/components-preview/search-controls` showing:
1. The filter sidebar visible on the page
2. Filter selections filled in
3. The emitted filter payload updating in the preview